### PR TITLE
Implement redirects for old URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,3 +48,5 @@ plugins:
 
 # Don't copy these files to the generated site
 exclude: [CNAME, Gemfile, Gemfile.lock, LICENSE.md, Rakefile, README.md, README-ld.md, vendor]
+# Include these else they don't take effect
+include: [_headers, _redirects]

--- a/_headers
+++ b/_headers
@@ -1,0 +1,4 @@
+/*
+Link: </css/style.css>; rel=preload; as=style
+/css/*
+  Cache-Control: public, max-age=86400

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,13 @@
+# Netlify redirects - see https://www.netlify.com/docs/redirects/
+#
+# Old                   New    Code if not 301
+
+# Gone pages
+/tag/*                  /       410
+/admin                  /       410
+
+# Redirects
+
+
+# Renames
+

--- a/_redirects
+++ b/_redirects
@@ -1,13 +1,13 @@
 # Netlify redirects - see https://www.netlify.com/docs/redirects/
 #
-# Old                   New    Code if not 301
+# Old                           New    Code if not 301
 
 # Gone pages
-/tag/*                  /       410
-/admin                  /       410
+/tag/*                          /       410
+/admin                          /       410
 
 # Redirects
-
+/smugmug-media-silo-plugin      /projects/smugmug-media-silo-plugin/
 
 # Renames
 


### PR DESCRIPTION
Life goes on and so the structure of this site has evolved over time leaving things stranded. Google kindly reminded me that I have several links that are now 404ing - they're been doing it for a while so no idea why the sudden interest now.

Anyway, this PR fixes this by introducing redirects supported by Netlify - https://www.netlify.com/docs/redirects/

Whilst I'm at it, also implementing headers for CSS files.